### PR TITLE
Fixing the pingdom client from interfering with tests

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -16,5 +16,6 @@ if(!defined('PINGDOM_API_KEY')) {
 	throw new RuntimeException('You must set PINGDOM_API_KEY in _ss_environment.php');
 }
 
-$api = new \Acquia\Pingdom\PingdomApi(PINGDOM_USERNAME, PINGDOM_PASSWORD, PINGDOM_API_KEY);
-Injector::inst()->registerService($api, 'PingdomService');
+Config::inst()->update('PingdomGateway', 'username', PINGDOM_USERNAME);
+Config::inst()->update('PingdomGateway', 'password', PINGDOM_PASSWORD);
+Config::inst()->update('PingdomGateway', 'key', PINGDOM_API_KEY);

--- a/_config/pingdom.yml
+++ b/_config/pingdom.yml
@@ -1,6 +1,0 @@
----
-name: deploynaut-notifications
----
-PingdomGateway:
-  dependencies:
-    pingdom: %$PingdomService

--- a/code/service/AlertService.php
+++ b/code/service/AlertService.php
@@ -9,6 +9,15 @@ class AlertService {
 	];
 
 	/**
+	 * @var PingdomGateway
+	 */
+	public $gateway;
+
+	public function setGateway($gateway) {
+		$this->gateway = $gateway;
+	}
+
+	/**
 	 * Output the raw content of the .alerts.yml file from HEAD of a bare repository.
 	 * @param DNProject $project
 	 * @param string $sha


### PR DESCRIPTION
Injector tries to create the PingdomApi without constructor arguments
which causes a fatal error during tests. Shift the client construction
to PingdomGateway on-demand, but store the credentials via Config on
bootstrap instead.